### PR TITLE
feat(user): use bcrypt email hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@trpc/react-query": "^10.9.0",
 				"@trpc/server": "^10.9.0",
 				"bcryptjs": "^2.4.3",
-				"crypto-random-string": "^5.0.0",
 				"formik": "^2.2.9",
 				"framer-motion": "^10.2.4",
 				"immer": "^9.0.19",
@@ -6784,6 +6783,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-5.0.0.tgz",
 			"integrity": "sha512-KWjTXWwxFd6a94m5CdRGW/t82Tr8DoBc9dNnPCAbFI1EBweN6v1tv8y4Y1m7ndkp/nkIBRxUxAzpaBnR2k3bcQ==",
+			"dev": true,
 			"dependencies": {
 				"type-fest": "^2.12.2"
 			},
@@ -6798,6 +6798,7 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
 			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
 			"engines": {
 				"node": ">=12.20"
 			},
@@ -20700,6 +20701,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-5.0.0.tgz",
 			"integrity": "sha512-KWjTXWwxFd6a94m5CdRGW/t82Tr8DoBc9dNnPCAbFI1EBweN6v1tv8y4Y1m7ndkp/nkIBRxUxAzpaBnR2k3bcQ==",
+			"dev": true,
 			"requires": {
 				"type-fest": "^2.12.2"
 			},
@@ -20707,7 +20709,8 @@
 				"type-fest": {
 					"version": "2.19.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"@trpc/react-query": "^10.9.0",
 		"@trpc/server": "^10.9.0",
 		"bcryptjs": "^2.4.3",
-		"crypto-random-string": "^5.0.0",
 		"formik": "^2.2.9",
 		"framer-motion": "^10.2.4",
 		"immer": "^9.0.19",

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -8,8 +8,6 @@ import { UserAuthLevel } from "@/utils/types"
 import bcrypt from "bcryptjs"
 import { TRPCError } from "@trpc/server"
 import { clearSessionData, saveSessionData } from "@/server/authHandlers"
-// @ts-expect-error
-import cryptoRandomString from "crypto-random-string/browser"
 import { sendPasswordReset, sendVerificationEmail } from "@/server/mail"
 
 const userRouter = createTRPCRouter({
@@ -81,7 +79,8 @@ const userRouter = createTRPCRouter({
 					message: "This email domain is not allowed",
 				})
 
-			const verificationToken = cryptoRandomString({ length: 64 })
+			// we hash the email to create the token, as it will be unique (bcrypt smart)
+			const verificationToken = bcrypt.hashSync(input.email)
 			const user = await ctx.prisma.user.create({
 				data: {
 					email: input.email,
@@ -146,7 +145,8 @@ const userRouter = createTRPCRouter({
 			// if there isnt a user, we send a success message to prevent email enumeration
 			if (!foundUser) return
 
-			const passwordResetToken = cryptoRandomString({ length: 64 })
+			// we hash the email to create the token, as it will be unique (bcrypt smart)
+			const passwordResetToken = bcrypt.hashSync(input)
 			const user = await ctx.prisma.user.update({
 				where: {
 					email: input,

--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -5,9 +5,12 @@ import { env } from "@/env.mjs"
 sendgrid.setApiKey(env.SENDGRID_API_KEY)
 
 export async function sendVerificationEmail(user: User, token: string) {
+	const qs = new URLSearchParams()
+	// auto URL encode the bcrypt hashed token
+	qs.append("token", token)
 	const verificationLink = `${
 		process.env.VERCEL_URL ? "https://" : "http://"
-	}${process.env.VERCEL_URL || "localhost:3000"}/user/verify?token=${token}`
+	}${process.env.VERCEL_URL || "localhost:3000"}/user/verify?${qs}`
 
 	await sendgrid.send({
 		to: user.email,
@@ -37,9 +40,12 @@ export function notifyNewReview(
 }
 
 export async function sendPasswordReset(user: User, token: string) {
+	const qs = new URLSearchParams()
+	// auto URL encode the bcrypt hashed token
+	qs.append("token", token)
 	const resetLink = `${process.env.VERCEL_URL ? "https://" : "http://"}${
 		process.env.VERCEL_URL || "localhost:3000"
-	}/user/passwordreset/new?token=${token}`
+	}/user/passwordreset/new?${qs}`
 	await sendgrid.send({
 		to: user.email,
 		from: env.EMAIL_USERNAME,


### PR DESCRIPTION
Use the bcrypt hashed email as the token for resetting a password and verifying an account. Removes the need for `crypto-random-string`.